### PR TITLE
Fixing i18n management for system message

### DIFF
--- a/CrossGambling.lua
+++ b/CrossGambling.lua
@@ -1348,8 +1348,8 @@ end
 
 function ParseChatRoll(tempString2)
 	local tempString1 = tempString2
-	local player, junk, actualRoll, range = strsplit(" ", tempString1)
-
+	local player, actualRoll, minRoll, maxRoll = strmatch(tempString1, "^([^ ]+) .+ (%d+) %((%d+)-(%d+)%)%.$")
+	
 	function CheckPlayers(player)
 		for i=1, #Players do
 			if (Players[i].Name == tostring(player)) then
@@ -1359,13 +1359,10 @@ function ParseChatRoll(tempString2)
 		return false
 	end
 
-
-	if junk == "rolls" and CheckPlayers(player)==true then
-		minRoll, maxRoll = strsplit("-",range)
-		minRoll = tonumber(strsub(minRoll,2))
-		maxRoll = tonumber(strsub(maxRoll,1,-2))
+	if CheckPlayers(player)==true then
+		minRoll = tonumber(minRoll)
+		maxRoll = tonumber(maxRoll)
 		actualRoll = tonumber(actualRoll)
-
 
 		if(minRoll == 1 and maxRoll == CurrentRollValue) then
 			SendEvent("PLAYER_ROLL", player..":"..tostring(actualRoll))

--- a/CrossGambling.lua
+++ b/CrossGambling.lua
@@ -1348,7 +1348,7 @@ end
 
 function ParseChatRoll(tempString2)
 	local tempString1 = tempString2
-	local player, actualRoll, minRoll, maxRoll = strmatch(tempString1, "^([^ ]+) .+ (%d+) %((%d+)-(%d+)%)%.$")
+	local player, actualRoll, minRoll, maxRoll = strmatch(tempString1, "^([^ ]+) .+ (%d+) %((%d+)-(%d+)%)%.?$")
 	
 	function CheckPlayers(player)
 		for i=1, #Players do


### PR DESCRIPTION
Fix the parse of /roll system messages for various languages using latin characters (the list can be found here https://github.com/tekkub/wow-globalstrings/tree/master/GlobalStrings, search for RANDOM_ROLL_RESULT key).

i haven't tested it for all languages tbh but i'm pretty confident in the regex. 