### PR TITLE
ElvUI compatibility

### DIFF
--- a/core/GUI.lua
+++ b/core/GUI.lua
@@ -16,12 +16,18 @@ local BackdropBorder = {
 }
 
 local SetTemplate = function(self)
+	if not self.SetBackdrop then
+		Mixin(self, BackdropTemplateMixin)
+	end
 	self:SetBackdrop(Backdrop)
 	self:SetBackdropBorderColor(0, 0, 0)
 	self:SetBackdropColor(0.27, 0.27, 0.27)
 end
 
 local SetTemplateDark = function(self)
+	if not self.SetBackdrop then
+		Mixin(self, BackdropTemplateMixin)
+	end
 	self:SetBackdrop(Backdrop)
 	self:SetBackdropBorderColor(0, 0, 0)
 	self:SetBackdropColor(0.17, 0.17, 0.17)


### PR DESCRIPTION
Observed when ElvUI is loaded the backdrop template isn't mixed in automatically.

    Message: Interface\AddOns\CrossGambling\core/GUI.lua:25: attempt to call method 'SetBackdrop' (a nil value)
    Time: Fri Mar 25 21:40:29 2022
    Count: 6
    Stack: Interface\AddOns\CrossGambling\core/GUI.lua:25: attempt to call method 'SetBackdrop' (a nil value)