### PR TITLE
Use GitHub Actions to build addon and push zip file to CurseForge and GitHub releases

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -1,0 +1,32 @@
+name: Package addon
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+      - '!**-beta**'
+      - '!**-alpha**'
+      - '!**-rc*'
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout addon
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Package
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -S
+        env:
+#          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/CrossGambling.toc
+++ b/CrossGambling.toc
@@ -1,4 +1,7 @@
-## Interface: 90100
+## Interface: 90200
+## Interface-BCC: 20503
+## Interface-Classic: 11402
+
 ## Title:|cffff7d0aCrossGambling
 ## Author: Azro
 ## 1.13 Maintainer: Fire @ Mal'Ganis
@@ -7,6 +10,9 @@
 ## LoadOnDemand: 0
 ## Notes: A fun way to lose gold. Or win it.
 ## SavedVariables: CrossGambling
+
+## X-Curse-Project-ID: 86458
+
 Libs.xml
 
 CrossGambling.lua


### PR DESCRIPTION
There were a few commits in this that I squashed for easier readability and merging.

The main changes are adding the `build-addon.yml` file which specifies the branch and tags to build off of. This will take effect when a tag such as `v9.2.0-04` is pushed, as can be seen [here](https://github.com/RiightX/CrossGambling/releases/tag/v9.2.0-04) on a push I tagged with `v9.2.0-04`.

in the `build-addon.yml` file is an environment variable of `CF_API_KEY: ${{ secrets.CF_API_KEY }}`. This can be set for uploading to CurseForge on tag pushes by going into the repo's Settings > Secrets > Actions menu, and adding a CurseForge API key (from [your Curse settings](https://www.curseforge.com/account/api-tokens). The secret name will be `CF_API_KEY` and the body of the secret will be the API key.

This pull also contains an update to the `.toc` file, adding version numbers for Classic, BCC and Retail. From what I could tell by the downloads on CurseForge, the only difference between the versions was the game version in the downloaded/zipped `.toc` file, and this should do the trick.

This will also have the GitHub Actions public a `.zip` folder to the GitHub repo, which will support clients like WoWUp (which can no longer pull from CurseForge).

Let me know if this sounds reasonable, thanks for taking the time to check it out!