### PR TITLE
Update CrossGambling.lua Tooltip

### DIFF
--- a/CrossGambling.lua
+++ b/CrossGambling.lua
@@ -205,7 +205,7 @@ end,
             end
             tooltip:AddDoubleLine("Cross Gambling", "|cFFAAAAAA" .. version .. "|r", 1, 0.82, 0, 1, 1, 1)
             tooltip:AddLine(" ")
-            tooltip:AddDoubleLine("|cFF66BBFFLeft-Click|r", "|cFFFFFFFFToggle CrossGambling Window|r")
+            tooltip:AddDoubleLine("|cFF00BBFFLeft-Click|r", "|cFFFFFFFFToggle CrossGambling Window|r")
         end,
 })
 minimapIcon:Register("CrossGamblingIcon", minimapLDB, self.db.global.minimap)


### PR DESCRIPTION
Hey mate, I made some small UX changes to your tooltip. 

<img width="281" height="123" alt="image" src="https://github.com/user-attachments/assets/6e54a808-2e33-4af6-87b5-d1cb1a3b0e23" />

Since you're using BigWigs Packager it'll populate the version instead of "Dev" with each deploy.