### PR TITLE
Update CrossGambling_TBC.toc

### DIFF
--- a/CrossGambling_TBC.toc
+++ b/CrossGambling_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20504
+## Interface: 20505
 ## Title:Cross|cffff7d0aGambling
 ## Author: Jay
 ## Version: @project-version@
@@ -35,4 +35,5 @@ core/ClassicGUI.lua
 core/Game.lua
 core/Stats.lua
 core/Events.lua
+
 


### PR DESCRIPTION
Hey mate, the latest for TBC is 2.5.5.  https://wago.tools/

Also, I didn't see any changes between these ToC files, so I think you'd be better off with just one ToC file... easier to maintain.

You can copy the format from this.

https://github.com/Gogo1951/Come-and-Get-It/blob/702901972a4d479092dc955f1fbfe62972edb067/ComeAndGetIt.toc#L9

> ## Interface: 11508, 20505, 50503, 110207