### PR TITLE
Update CrossGambling_TBC.toc

### DIFF
--- a/CrossGambling_TBC.toc
+++ b/CrossGambling_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20504, 20505
+## Interface: 20505
 ## Title:Cross|cffff7d0aGambling
 ## Author: Jay
 ## Version: @project-version@
@@ -35,5 +35,6 @@ core/ClassicGUI.lua
 core/Game.lua
 core/Stats.lua
 core/Events.lua
+
 
 


### PR DESCRIPTION
Updated for TBC so it'll show 2.5.5.

Still shows 2.5.4 as it was set up.

<img width="850" height="137" alt="image" src="https://github.com/user-attachments/assets/6e441e8e-d3e2-412d-8672-ae89463863b0" />
