### PR TITLE
Adjusting RollNotification

### DIFF
--- a/core/Game.lua
+++ b/core/Game.lua
@@ -172,10 +172,10 @@ function CrossGambling:CloseGame()
             for i = 1, #self.game.result.losers do
                 local RollNotification
                 if self.game.house == true then
-                    RollNotification = self.game.result.losers[i].name .. " owes " .. self.game.result.winners[i].name .. " " .. self:addCommas(self.game.result.amountOwed) .. " gold! plus " .. self:addCommas(houseAmount) .. " to the guild"
+                    RollNotification = self.game.result.losers[i].name .. " owes " .. self.game.result.winners[i].name .. " " .. self:addCommas(self.game.result.amountOwed) .. " g! plus " .. self:addCommas(houseAmount) .. " to the guild"
                     self:updatePlayerStat("guild", houseAmount)
                 else
-                    RollNotification = self.game.result.losers[i].name .. " owes " .. self.game.result.winners[i].name .. " " .. self:addCommas(self.game.result.amountOwed) .. " gold!"
+                    RollNotification = self.game.result.losers[i].name .. " owes " .. self.game.result.winners[i].name .. " " .. self:addCommas(self.game.result.amountOwed) .. " g!"
                 end
 
                 if self.game.chatframeOption == false and self.game.host == true then


### PR DESCRIPTION
Adjusting the RollNotification message, truncating "gold!" to "g!" to account for rare conflicts with message filtering.

Messages matching `^.*(?i)thu[^a-z]*gold.*$` fail to post. Unsure if this applies to other 3-character names, but it definitely applies to "Thu".

Steps to recreate? Try to send a message to any destination (/say, /instance, /party, /guild, etc.) matching the regex: "Jorjji owes Thu 91,368 gold!"

I've reported this as a bug with Blizzard; however, I don't know if it can or when it will be fixed on their end. In the meantime, since I'm unsure of the scope of the bug, this workaround should prevent issues moving forward.