### PR TITLE
Improve performance with optimized player updates and boss/PvP chat pausing

### DIFF
--- a/CrossGambling.lua
+++ b/CrossGambling.lua
@@ -290,6 +290,10 @@ function CrossGambling:OnInitialize()
 	self:InitDB()
 	self:InitMinimap()
 	self:DrawSecondEvents()
+	self:RegisterEvent("PLAYER_REGEN_DISABLED", "OnCombatStart")
+	self:RegisterEvent("PLAYER_REGEN_ENABLED", "OnCombatEnd")
+	self:RegisterEvent("ENCOUNTER_START", "OnEncounterStart")
+	self:RegisterEvent("ENCOUNTER_END", "OnEncounterEnd")
 	self:RegisterChatCommand("CrossGambling", "HandleSlashCommand")
 	self:RegisterChatCommand("cg", "HandleSlashCommand")
 	self.uiBuilt = false
@@ -426,6 +430,7 @@ function CrossGambling:InitDB()
             auditLog = {},
             auditRetention = 30,
             auditMaxEntries = 500,
+            suspendChatEventsInCombat = true,
 },
 }
 
@@ -532,7 +537,46 @@ function CrossGambling:SendChat(msg, method)
   pcall(SendChatMessage, msg, method or self.game.chatMethod)
 end
 
+function CrossGambling:ShouldSuspendChatEventsInCombat()
+	return self.db
+		and self.db.global
+		and self.db.global.suspendChatEventsInCombat ~= false
+		and InCombatLockdown()
+		and self:IsHighImpactCombatContext()
+end
+
+function CrossGambling:IsHighImpactCombatContext()
+	if self.bossEncounterActive then
+		return true
+	end
+
+	local _, instanceType = IsInInstance()
+	return instanceType == "arena" or instanceType == "pvp"
+end
+
+function CrossGambling:SuspendRegistrationChatEvents()
+	if self.game.state ~= gameStates[2] then
+		return
+	end
+
+	self.chatEventsSuspendedForCombat = true
+	self:UnRegisterChatEvents()
+end
+
+function CrossGambling:ResumeRegistrationChatEvents()
+	if self.chatEventsSuspendedForCombat and self.game.state == gameStates[2] then
+		self:RegisterChatEvents()
+	end
+end
+
 function CrossGambling:RegisterChatEvents()
+	if self:ShouldSuspendChatEventsInCombat() then
+		self:SuspendRegistrationChatEvents()
+		return
+	end
+
+	self.chatEventsSuspendedForCombat = false
+
     if self.game.chatMethod == chatMethods[1] then
         self:RegisterEvent("CHAT_MSG_PARTY", "handleChatMsg")
         self:RegisterEvent("CHAT_MSG_PARTY_LEADER", "handleChatMsg")
@@ -543,6 +587,32 @@ function CrossGambling:RegisterChatEvents()
     else
         self:RegisterEvent("CHAT_MSG_GUILD", "handleChatMsg")
     end
+end
+
+function CrossGambling:OnCombatStart()
+	if self:ShouldSuspendChatEventsInCombat() then
+		self:SuspendRegistrationChatEvents()
+	end
+end
+
+function CrossGambling:OnCombatEnd()
+	self:ResumeRegistrationChatEvents()
+end
+
+function CrossGambling:OnEncounterStart()
+	self.bossEncounterActive = true
+
+	if self:ShouldSuspendChatEventsInCombat() then
+		self:SuspendRegistrationChatEvents()
+	end
+end
+
+function CrossGambling:OnEncounterEnd()
+	self.bossEncounterActive = false
+
+	if not self:ShouldSuspendChatEventsInCombat() then
+		self:ResumeRegistrationChatEvents()
+	end
 end
 
 function CrossGambling:chatMethod()
@@ -571,6 +641,12 @@ end
 
 
 function CrossGambling:handleChatMsg(_, text, playerName)
+	if self:ShouldSuspendChatEventsInCombat() then
+		self.chatEventsSuspendedForCombat = true
+		self:UnRegisterChatEvents()
+		return
+	end
+
     if (self.game.state == gameStates[2]) then
         local playerName = strsplit("-", playerName, 2)
         self:RegisterGame(text, playerName)

--- a/CrossGambling.lua
+++ b/CrossGambling.lua
@@ -181,6 +181,55 @@ local function isPlayerBanned(addon, playerName)
 	return false
 end
 
+function CrossGambling:NormalizePlayerName(name, preserveRealm)
+	if not name then
+		return nil
+	end
+
+	name = strtrim(tostring(name))
+	if name == "" then
+		return nil
+	end
+
+	if not preserveRealm then
+		name = strsplit("-", name, 2)
+		if not name or name == "" then
+			return nil
+		end
+	end
+
+	return strlower(name)
+end
+
+function CrossGambling:RebuildBanCache()
+	self.banLookup = {}
+
+	local bans = self.db and self.db.global and self.db.global.bans
+	if not bans then
+		return
+	end
+
+	for i = 1, #bans do
+		local normalizedName = self:NormalizePlayerName(bans[i])
+		if normalizedName then
+			self.banLookup[normalizedName] = true
+		end
+	end
+end
+
+function CrossGambling:IsPlayerBanned(playerName)
+	local normalizedPlayerName = self:NormalizePlayerName(playerName)
+	if not normalizedPlayerName then
+		return false
+	end
+
+	if not self.banLookup then
+		self:RebuildBanCache()
+	end
+
+	return self.banLookup[normalizedPlayerName] == true
+end
+
 function CrossGambling:PrintCommandHelp()
 	self:Print("Commands: show, hide, minimap, allstats, stats, joinstats, unjoinstats, listalts, updatestat, deletestat, resetstats, ban, unban, listbans, audit")
 	self:Print("Usage: /cg <command> [value]")
@@ -395,9 +444,10 @@ function CrossGambling:InitDB()
 				sessionStats = {},
 			}
 
-    CGCall = {}
+	CGCall = {}
 	self.db = LibStub("AceDB-3.0"):New("CrossGambling", defaults, true)
 	if(CrossGambling["stats"]) then CrossGambling["stats"] = self.db.global.stats end
+	self:RebuildBanCache()
 	
 end
 
@@ -649,6 +699,7 @@ function CrossGambling:banPlayer(info, playerName)
     end
 
     table.insert(self.db.global.bans, playerName)
+    self:RebuildBanCache()
     self:RemovePlayer(playerName)
     self:unregisterPlayer(playerName)
     self:Print(playerName .. " has been added to the ban list.")
@@ -671,6 +722,7 @@ function CrossGambling:unbanPlayer(info, playerName)
 
     if playerIndex then
         table.remove(self.db.global.bans, playerIndex)
+        self:RebuildBanCache()
         self:Print(playerName .. " has been removed from the ban list.")
     else
         self:Print(playerName .. " is not currently banned!")
@@ -721,12 +773,19 @@ end
 
 
 function CrossGambling:getPlayerByName(name)
-    for i = 1, #self.game.players do
-        if self.game.players[i].name == name then
-            return self.game.players[i]
+    local players = self.game.players
+    local indexByName = self.game.playerIndexByName
+
+    if not indexByName then
+        indexByName = {}
+        for i = 1, #players do
+            indexByName[players[i].name] = i
         end
+        self.game.playerIndexByName = indexByName
     end
-    return nil
+
+    local playerIndex = indexByName[name]
+    return playerIndex and players[playerIndex] or nil
 end
 
 function CrossGambling:hasPendingRolls()
@@ -796,13 +855,22 @@ end
 
 
 function CrossGambling:registerPlayer(playerName, playerRoll)
-    for i = 1, #self.game.players do
-        if (self.game.players[i].name == playerName) then
-            return
+    local players = self.game.players
+    local indexByName = self.game.playerIndexByName
+
+    if not indexByName then
+        indexByName = {}
+        self.game.playerIndexByName = indexByName
+        for i = 1, #players do
+            indexByName[players[i].name] = i
         end
     end
 
-    if isPlayerBanned(self, playerName) then
+    if indexByName[playerName] then
+        return
+    end
+
+    if self:IsPlayerBanned(playerName) then
 		if(self.game.chatframeOption == false and self.game.host == true) then
 			local RollNotification = "Sorry " .. playerName .. ", you're banned."
 			self:SendMsg(format("CHAT_MSG:%s:%s:%s", self.game.PlayerName, self.game.PlayerClass, RollNotification))
@@ -817,21 +885,31 @@ function CrossGambling:registerPlayer(playerName, playerRoll)
         roll = playerRoll
     }
 	
-    tinsert(self.game.players, newRegister)
+    local newIndex = #players + 1
+    players[newIndex] = newRegister
+    indexByName[playerName] = newIndex
 end
 
 function CrossGambling:unregisterPlayer(playerName)
-    for i = 1, #self.game.players do
-        if (self.game.players[i].name == playerName) then         
-		   tremove(self.game.players, i)
-            return
-        end
+    local players = self.game.players
+    local indexByName = self.game.playerIndexByName
+    local playerIndex = indexByName and indexByName[playerName]
+    if not playerIndex then
+        return
+    end
+
+    tremove(players, playerIndex)
+    indexByName[playerName] = nil
+
+    for i = playerIndex, #players do
+        indexByName[players[i].name] = i
     end
 end
 
 
 
 function CrossGambling:UnRegisterChatEvents()
+        self.chatEventsRegistered = false
         self:UnregisterEvent("CHAT_MSG_PARTY")
         self:UnregisterEvent("CHAT_MSG_PARTY_LEADER")
         self:UnregisterEvent("CHAT_MSG_RAID")

--- a/chat/CGOptions.lua
+++ b/chat/CGOptions.lua
@@ -558,9 +558,28 @@ function CGOptions:Build(isSlick)
         self:Refresh(self._state)
     end)
 
-    RowLabel(gamePanel, START_Y - ROW_H*3, "Join Word:")
+    RowLabel(gamePanel, START_Y - ROW_H*3, "Pause Boss/PvP:")
+    local combatChatBtn = MakeToggleBtn(gamePanel, 85, 22)
+    combatChatBtn:SetPoint("TOPLEFT", gamePanel, "TOPLEFT", VAL_X, START_Y - ROW_H*3 + 4)
+    combatChatBtn:SetScript("OnClick", function(self)
+        local a = GetAddon()
+        if not a or not a.db or not a.db.global then return end
+
+        self._state = not self._state
+        a.db.global.suspendChatEventsInCombat = self._state
+        self:Refresh(self._state)
+
+        if type(a.ShouldSuspendChatEventsInCombat) == "function" and a:ShouldSuspendChatEventsInCombat() then
+            a.chatEventsSuspendedForCombat = true
+            a:UnRegisterChatEvents()
+        elseif a.chatEventsSuspendedForCombat and a.game and a.game.state == "REGISTER" then
+            a:RegisterChatEvents()
+        end
+    end)
+
+    RowLabel(gamePanel, START_Y - ROW_H*4, "Join Word:")
     local joinEB = MakeEditBox(gamePanel, 85, 22, 10)
-    joinEB:SetPoint("TOPLEFT", gamePanel, "TOPLEFT", VAL_X, START_Y - ROW_H*3 + 4)
+    joinEB:SetPoint("TOPLEFT", gamePanel, "TOPLEFT", VAL_X, START_Y - ROW_H*4 + 4)
     joinEB:SetText("1")
     joinEB:SetScript("OnEditFocusLost", function(self)
         self:HighlightText(0,0)
@@ -573,9 +592,9 @@ function CGOptions:Build(isSlick)
         self:ClearFocus()
     end)
 
-    RowLabel(gamePanel, START_Y - ROW_H*4, "Leave Word:")
+    RowLabel(gamePanel, START_Y - ROW_H*5, "Leave Word:")
     local leaveEB = MakeEditBox(gamePanel, 85, 22, 10)
-    leaveEB:SetPoint("TOPLEFT", gamePanel, "TOPLEFT", VAL_X, START_Y - ROW_H*4 + 4)
+    leaveEB:SetPoint("TOPLEFT", gamePanel, "TOPLEFT", VAL_X, START_Y - ROW_H*5 + 4)
     leaveEB:SetText("-1")
     leaveEB:SetScript("OnEditFocusLost", function(self)
         self:HighlightText(0,0)
@@ -588,9 +607,9 @@ function CGOptions:Build(isSlick)
         self:ClearFocus()
     end)
 
-    Divider(gamePanel, START_Y - ROW_H*5 - 4)
+    Divider(gamePanel, START_Y - ROW_H*6 - 4)
 
-    local statY = START_Y - ROW_H*5 - 12
+    local statY = START_Y - ROW_H*6 - 12
     local BW, BH = 138, 26
     local statsX = isSlick and 21 or 0
 
@@ -629,6 +648,7 @@ function CGOptions:Build(isSlick)
         if not a or not a.game then return end
         guildCutBtn:Refresh(a.game.house)
         realmBtn:Refresh(a.game.realmFilter)
+        combatChatBtn:Refresh(a.db.global.suspendChatEventsInCombat ~= false)
         houseCutEB:SetText(tostring(a.db.global.houseCut or 10))
         joinEB:SetText(a.db.global.joinWord or "1")
         leaveEB:SetText(a.db.global.leaveWord or "-1")

--- a/core/ClassicGUI.lua
+++ b/core/ClassicGUI.lua
@@ -44,6 +44,8 @@ end
 local CGPlayers = {}
 local playerButtons = {}
 local playerButtonsFrame
+local playerIndexByName = {}
+local pendingPlayerListRefresh = false
 local function GetAddonRef()
     local ok, addon = pcall(function()
         return LibStub("AceAddon-3.0"):GetAddon("CrossGambling")
@@ -939,13 +941,45 @@ CGMenuToggle:SetScript("OnMouseDown", function(self)
 end)
 
 function CrossGambling:RemovePlayer(name)
+    local playerIndex = playerIndexByName[name]
+    if not playerIndex then
+        return
+    end
 
-    for i, player in pairs(CGPlayers) do
-        if player.name == name then
-            table.remove(CGPlayers, i)
-            self:UpdatePlayerList()
-            return
+    table.remove(CGPlayers, playerIndex)
+    playerIndexByName[name] = nil
+
+    for i = playerIndex, #CGPlayers do
+        playerIndexByName[CGPlayers[i].name] = i
+    end
+
+    self:QueuePlayerListRefresh()
+end
+
+function CrossGambling:QueuePlayerListRefresh()
+    if pendingPlayerListRefresh then
+        return
+    end
+
+    pendingPlayerListRefresh = true
+    C_Timer.After(0, function()
+        pendingPlayerListRefresh = false
+        CrossGambling:UpdatePlayerList()
+    end)
+end
+
+local function InsertPlayerSorted(player)
+    local insertIndex = #CGPlayers + 1
+    for i = 1, #CGPlayers do
+        if player.name < CGPlayers[i].name then
+            insertIndex = i
+            break
         end
+    end
+
+    table.insert(CGPlayers, insertIndex, player)
+    for i = insertIndex, #CGPlayers do
+        playerIndexByName[CGPlayers[i].name] = i
     end
 end
 
@@ -955,20 +989,15 @@ function CrossGambling:AddPlayer(playerName)
         return
     end
 
-    for i, player in pairs(CGPlayers) do
-        if player.name == playerName then
-            return
-        end
+    if playerIndexByName[playerName] then
+        return
     end
     local newPlayer = {
         name = playerName,
         total = 0,
     }
-    table.insert(CGPlayers, newPlayer)
-    table.sort(CGPlayers, function(a, b)
-        return a.name < b.name
-    end)
-    self:UpdatePlayerList()
+    InsertPlayerSorted(newPlayer)
+    self:QueuePlayerListRefresh()
 end
 
 local playerListFrame = CreateFrame("Frame", "PlayerListFrame", CGLeftMenu)
@@ -995,10 +1024,6 @@ scrollFrame:SetScrollChild(playerButtonsFrame)
 playerButtons = {}
 
 function CrossGambling:UpdatePlayerList()
-    table.sort(CGPlayers, function(a, b)
-        return a.name < b.name
-    end)
-
     for i, button in ipairs(playerButtons) do
         button:Hide()
     end
@@ -1029,19 +1054,17 @@ end
 
 
 CGCall["PLAYER_ROLL"] = function(playerName, value)
-    for i, player in pairs(CGPlayers) do
-        if player.name == playerName then
-            player.roll = value 
-            break
-        end
+    local playerIndex = playerIndexByName[playerName]
+    if playerIndex then
+        CGPlayers[playerIndex].roll = value
     end
-    CrossGambling:UpdatePlayerList()
+    CrossGambling:QueuePlayerListRefresh()
 end
 
 CGCall["R_NewGame"] = function()
-    for i = #CGPlayers, 1, -1 do
-        CrossGambling:RemovePlayer(CGPlayers[i].name)
-    end
+    wipe(CGPlayers)
+    wipe(playerIndexByName)
+    CrossGambling:QueuePlayerListRefresh()
 CGEnter_UpdateJoinText()
 CGStartRoll:SetText("Start Rolling")
 CGEnter:Enable()
@@ -1054,6 +1077,7 @@ CGCall["DisableClient"] = function()
 		CGLastCall:Disable()
 		CGStartRoll:Disable()
 		CrossGambling.game.players = {}
+		CrossGambling.game.playerIndexByName = nil
 		CrossGambling.game.result = nil
 	if(CrossGambling.game.host) then
 		CGAcceptOnes:Enable()

--- a/core/GUI.lua
+++ b/core/GUI.lua
@@ -44,6 +44,8 @@ end
 local CGPlayers = {}
 local playerButtons = {}
 local playerButtonsFrame
+local playerIndexByName = {}
+local pendingPlayerListRefresh = false
 local CG = "Interface\\AddOns\\CrossGambling\\media\\CG.tga"
 local Backdrop = {
 	bgFile = CG,
@@ -1243,12 +1245,45 @@ CGMenuToggle:SetScript("OnMouseDown", function(self)
 end)
 
 function CrossGambling:RemovePlayer(name)
-    for i, player in pairs(CGPlayers) do
-        if player.name == name then
-            table.remove(CGPlayers, i)
-            self:UpdatePlayerList()
-            return
+    local playerIndex = playerIndexByName[name]
+    if not playerIndex then
+        return
+    end
+
+    table.remove(CGPlayers, playerIndex)
+    playerIndexByName[name] = nil
+
+    for i = playerIndex, #CGPlayers do
+        playerIndexByName[CGPlayers[i].name] = i
+    end
+
+    self:QueuePlayerListRefresh()
+end
+
+function CrossGambling:QueuePlayerListRefresh()
+    if pendingPlayerListRefresh then
+        return
+    end
+
+    pendingPlayerListRefresh = true
+    C_Timer.After(0, function()
+        pendingPlayerListRefresh = false
+        CrossGambling:UpdatePlayerList()
+    end)
+end
+
+local function InsertPlayerSorted(player)
+    local insertIndex = #CGPlayers + 1
+    for i = 1, #CGPlayers do
+        if player.name < CGPlayers[i].name then
+            insertIndex = i
+            break
         end
+    end
+
+    table.insert(CGPlayers, insertIndex, player)
+    for i = insertIndex, #CGPlayers do
+        playerIndexByName[CGPlayers[i].name] = i
     end
 end
 
@@ -1258,21 +1293,16 @@ function CrossGambling:AddPlayer(playerName)
         return
     end
 
-    for i, player in pairs(CGPlayers) do
-        if player.name == playerName then
-            return
-        end
+    if playerIndexByName[playerName] then
+        return
     end
 
     local newPlayer = {
         name = playerName,
         total = 0,
     }
-    table.insert(CGPlayers, newPlayer)
-    table.sort(CGPlayers, function(a, b)
-        return a.name < b.name
-    end)
-    self:UpdatePlayerList()
+    InsertPlayerSorted(newPlayer)
+    self:QueuePlayerListRefresh()
 end
 
 local playerListFrame = CreateFrame("Frame", "PlayerListFrame", CGLeftMenu)
@@ -1304,10 +1334,6 @@ function CrossGambling:UpdatePlayerList()
     for i, button in ipairs(playerButtons) do
         button:Hide()
     end
-
-    table.sort(CGPlayers, function(a, b)
-        return a.name < b.name
-    end)
 
     local row = 0
 
@@ -1359,19 +1385,17 @@ end
 
 
 CGCall["PLAYER_ROLL"] = function(playerName, value)
-    for i, player in pairs(CGPlayers) do
-        if player.name == playerName then
-            player.roll = value 
-            break
-        end
+    local playerIndex = playerIndexByName[playerName]
+    if playerIndex then
+        CGPlayers[playerIndex].roll = value
     end
-    CrossGambling:UpdatePlayerList()
+    CrossGambling:QueuePlayerListRefresh()
 end
 
 CGCall["R_NewGame"] = function()
-    for i = #CGPlayers, 1, -1 do
-        CrossGambling:RemovePlayer(CGPlayers[i].name)
-    end
+    wipe(CGPlayers)
+    wipe(playerIndexByName)
+    CrossGambling:QueuePlayerListRefresh()
 	CGEnter_UpdateJoinText()
 	CGStartRoll:SetText("Start Rolling")
 	CGEnter:Enable()
@@ -1382,6 +1406,7 @@ CGCall["DisableClient"] = function()
 		CGLastCall:Disable()
 		CGStartRoll:Disable()
 		CrossGambling.game.players = {}
+		CrossGambling.game.playerIndexByName = nil
 		CrossGambling.game.result = nil
 	if(CrossGambling.game.host) then
 		CGAcceptOnes:Enable()

--- a/core/Game.lua
+++ b/core/Game.lua
@@ -151,6 +151,7 @@ function CrossGambling:detectTie()
 
         if #tiedPlayers > 1 then
             self.game.players = tiedPlayers
+            self.game.playerIndexByName = nil
             for i = 1, #self.game.players do
                 self.game.players[i].roll = nil
             end
@@ -221,6 +222,7 @@ function CrossGambling:CloseGame()
     self.currentRoll  = nil
     self.game.state   = "START"
     self.game.players = {}
+    self.game.playerIndexByName = nil
     self.game.result  = nil
     self.game.host    = false
 

--- a/modes/BigTwoMode.lua
+++ b/modes/BigTwoMode.lua
@@ -8,15 +8,13 @@ end
 function BigTwoMode:OnRollReceived(addon, game, playerName, actualRoll, minRoll, maxRoll)
     if minRoll ~= 1 or maxRoll ~= addon.db.global.wager then return end
 
-    for i = 1, #game.players do
-        local player = game.players[i]
-        if player.name == playerName and player.roll == nil then
-            player.roll = actualRoll
-            if CGCall and CGCall["PLAYER_ROLL"] then
-                CGCall["PLAYER_ROLL"](playerName, tostring(actualRoll))
-            end
-            addon:SendMsg("PLAYER_ROLL", playerName .. ":" .. tostring(actualRoll))
+    local player = addon:getPlayerByName(playerName)
+    if player and player.roll == nil then
+        player.roll = actualRoll
+        if CGCall and CGCall["PLAYER_ROLL"] then
+            CGCall["PLAYER_ROLL"](playerName, tostring(actualRoll))
         end
+        addon:SendMsg("PLAYER_ROLL", playerName .. ":" .. tostring(actualRoll))
     end
 
     if #addon:CheckRolls() == 0 then

--- a/modes/ClassicMode.lua
+++ b/modes/ClassicMode.lua
@@ -4,15 +4,13 @@ ClassicMode.name  = "Classic"
 function ClassicMode:OnRollReceived(addon, game, playerName, actualRoll, minRoll, maxRoll)
     if minRoll ~= 1 or maxRoll ~= addon.db.global.wager then return end
 
-    for i = 1, #game.players do
-        local player = game.players[i]
-        if player.name == playerName and player.roll == nil then
-            player.roll = actualRoll
-            if CGCall and CGCall["PLAYER_ROLL"] then
-                CGCall["PLAYER_ROLL"](playerName, tostring(actualRoll))
-            end
-            addon:SendMsg("PLAYER_ROLL", playerName .. ":" .. tostring(actualRoll))
+    local player = addon:getPlayerByName(playerName)
+    if player and player.roll == nil then
+        player.roll = actualRoll
+        if CGCall and CGCall["PLAYER_ROLL"] then
+            CGCall["PLAYER_ROLL"](playerName, tostring(actualRoll))
         end
+        addon:SendMsg("PLAYER_ROLL", playerName .. ":" .. tostring(actualRoll))
     end
 
     if #addon:CheckRolls() == 0 then

--- a/modes/DeathRollMode.lua
+++ b/modes/DeathRollMode.lua
@@ -53,6 +53,7 @@ function DeathRollMode:OnRollReceived(addon, game, playerName, actualRoll, minRo
         addon:UnregisterEvent("CHAT_MSG_SYSTEM")
         addon.game.state   = "START"
         addon.game.players = {}
+        addon.game.playerIndexByName = nil
         addon.game.result  = nil
     else
         addon.currentRoll        = actualRoll


### PR DESCRIPTION
## Summary

This PR improves CrossGambling runtime performance by reducing repeated player-list work and limiting registration chat listeners during the most performance-sensitive combat contexts.

The main changes are:

- cache player and ban lookups instead of repeatedly scanning tables
- batch player-list UI refreshes
- avoid repeated full player-list sorting
- pause registration chat listeners during boss encounters, arenas, and battlegrounds
- keep join/leave chat active during normal trash pulls

## What Changed

### Optimized player and ban lookups

CrossGambling now maintains faster lookup tables for active players and banned players.

Previously, several hot paths repeatedly scanned tables to find players or check bans. This affected join handling, leave handling, roll handling, and ban validation.

This PR adds:

- normalized ban lookup caching
- active player indexing by name
- index cleanup when players are removed
- index reset when game player state is replaced or cleared

This reduces repeated linear scans during active games.

### Reduced player-list UI churn

The player-list UI now avoids unnecessary redraw work.

Previously, the addon could sort and refresh the full visible player list after every join, leave, roll update, and reset operation. During bursts of activity, that created avoidable UI churn.

This PR changes the UI update path to:

- keep player entries sorted on insertion
- avoid full resorting on every refresh
- batch player-list refreshes with `C_Timer.After(0, ...)`
- clear the list in one operation during game reset

Both Slick and Classic UI paths were updated.

### Updated roll handlers

Classic and BigTwo roll handlers now use the faster player lookup path instead of scanning the full player list for each roll.

This reduces work during the roll phase and keeps mode handling aligned with the new indexed player state.

### Added boss/PvP chat listener pausing

A new default-enabled setting was added:

`Pause Boss/PvP`

When enabled, CrossGambling pauses registration chat listeners only during high-impact combat contexts:

- boss encounters
- arenas
- battlegrounds

This avoids processing join/leave chat events during the places where combat performance matters most, while still allowing players to use CrossGambling during normal trash pulls.

Trash pulls do not pause chat listeners.

## Behavior Details

When `Pause Boss/PvP` is enabled:

- registration chat listeners remain active during normal non-boss combat
- registration chat listeners pause during boss encounters
- registration chat listeners pause in arenas
- registration chat listeners pause in battlegrounds
- listeners resume when the pause context ends and registration is still open

If users want the old behavior everywhere, they can disable `Pause Boss/PvP` in the Game options tab.

## Files Changed

- `CrossGambling.lua`
  - added normalized player name helper
  - added ban cache
  - added active player lookup index
  - added boss/PvP-aware chat suspension logic
  - added encounter event handling

- `chat/CGOptions.lua`
  - added `Pause Boss/PvP` toggle to the Game tab

- `core/GUI.lua`
  - batched Slick player-list refreshes
  - avoided repeated sorting
  - added indexed visible-player tracking

- `core/ClassicGUI.lua`
  - applied the same player-list refresh improvements to Classic UI

- `core/Game.lua`
  - clears player lookup state when replacing or resetting game players

- `modes/ClassicMode.lua`
  - uses direct player lookup for roll handling

- `modes/BigTwoMode.lua`
  - uses direct player lookup for roll handling

- `modes/DeathRollMode.lua`
  - clears player lookup state when resetting game players

## Testing Notes

Lua syntax validation was not run locally because `lua` and `luac` are not installed in the workspace.

Recommended in-game testing:

- Start registration outside combat and confirm join/leave commands work.
- Start a trash pull and confirm join/leave commands still work.
- Start a boss encounter and confirm registration chat listeners pause.
- End the boss encounter and confirm listeners resume if registration is still open.
- Enter a battleground and confirm listeners pause during combat.
- Enter an arena and confirm listeners pause during combat.
- Disable `Pause Boss/PvP` and confirm registration chat listeners remain active in those contexts.
- Test both Slick and Classic UI themes.
- Test Classic, BigTwo, and 1v1DeathRoll modes.
- Confirm player list updates correctly for join, leave, roll, reset, and tie-breaker flows.